### PR TITLE
Dockefile: Fix build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
 # RUN ls -laR
 RUN npm install --silent
 COPY . .
-RUN npm run build
+RUN npm run build:server
 # RUN ls -la
 # RUN ls -laR dist/
 CMD ["node", "dist/app.js"]


### PR DESCRIPTION
Fix #73

Replace 'npm run build' with 'rpm run build:server'

Commit e0aba58997a2477f32b8ab916480f670842fa85f introduced a regression
by replacing npm script "build" with "build:server".

This is quick fix to make top level Dockerfile build again.

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>